### PR TITLE
Add zoom controls and initial user centering

### DIFF
--- a/Tropka/Info.plist
+++ b/Tropka/Info.plist
@@ -4,7 +4,9 @@
 <dict>
 	<key>MBXAccessToken</key>
 	<string>pk.eyJ1IjoidHJhdmVsYXBwLWNvbSIsImEiOiJjbWFpNDk3cWcwaWZqMmtzNzBsZmh0eG9rIn0.SMeV0YAQGa0riQZ9jvc5aQ</string>
-	<key>MGLMapboxAccessToken</key>
-	<string>pk.eyJ1IjoidHJhdmVsYXBwLWNvbSIsImEiOiJjbWFpNDk3cWcwaWZqMmtzNzBsZmh0eG9rIn0.SMeV0YAQGa0riQZ9jvc5aQ</string>
+        <key>MGLMapboxAccessToken</key>
+        <string>pk.eyJ1IjoidHJhdmVsYXBwLWNvbSIsImEiOiJjbWFpNDk3cWcwaWZqMmtzNzBsZmh0eG9rIn0.SMeV0YAQGa0riQZ9jvc5aQ</string>
+        <key>NSLocationWhenInUseUsageDescription</key>
+        <string>This app needs your location to show where you are on the map.</string>
 </dict>
 </plist>

--- a/Tropka/Views/Map/MapboxMapView.swift
+++ b/Tropka/Views/Map/MapboxMapView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import MapboxMaps
+import CoreLocation
 
 /// UIKit wrapper for Mapbox Maps SDK that displays annotations for places.
 struct MapboxMapView: UIViewRepresentable {
@@ -13,9 +14,7 @@ struct MapboxMapView: UIViewRepresentable {
         let mv = MapView(frame: .zero, mapInitOptions: options)
         mv.location.options.puckType = .puck2D()
 
-        context.coordinator.annotationManager = mv.annotations.makePointAnnotationManager()
-        context.coordinator.mapView = mv
-        context.coordinator.onPinTapped = onPinTapped
+        context.coordinator.setup(with: mv, onPinTapped: onPinTapped)
         context.coordinator.updateAnnotations(with: places)
         return mv
     }
@@ -25,10 +24,38 @@ struct MapboxMapView: UIViewRepresentable {
         context.coordinator.updateAnnotations(with: places)
     }
 
-    class Coordinator {
+    class Coordinator: NSObject, CLLocationManagerDelegate {
         var annotationManager: PointAnnotationManager?
         weak var mapView: MapView?
         var onPinTapped: ((Place) -> Void)?
+
+        private let locationManager = CLLocationManager()
+        private var hasCenteredOnUser = false
+
+        override init() {
+            super.init()
+            locationManager.delegate = self
+            NotificationCenter.default.addObserver(self,
+                                                   selector: #selector(handleZoomIn),
+                                                   name: .zoomIn,
+                                                   object: nil)
+            NotificationCenter.default.addObserver(self,
+                                                   selector: #selector(handleZoomOut),
+                                                   name: .zoomOut,
+                                                   object: nil)
+        }
+
+        func setup(with mapView: MapView, onPinTapped: @escaping (Place) -> Void) {
+            self.mapView = mapView
+            self.annotationManager = mapView.annotations.makePointAnnotationManager()
+            self.onPinTapped = onPinTapped
+            locationManager.requestWhenInUseAuthorization()
+            locationManager.startUpdatingLocation()
+
+            if let loc = locationManager.location {
+                centerOnUser(loc)
+            }
+        }
 
         func updateAnnotations(with places: [Place]) {
             guard let manager = annotationManager else { return }
@@ -62,6 +89,42 @@ struct MapboxMapView: UIViewRepresentable {
                     icon.draw(in: iconRect)
                 }
             }
+        }
+
+        // MARK: - Zoom Handling
+
+        @objc private func handleZoomIn() {
+            changeZoom(by: 1)
+        }
+
+        @objc private func handleZoomOut() {
+            changeZoom(by: -1)
+        }
+
+        private func changeZoom(by delta: CGFloat) {
+            guard let mapView else { return }
+            let current = mapView.cameraState.zoom
+            let options = CameraOptions(zoom: current + Double(delta))
+            mapView.mapboxMap.setCamera(to: options)
+        }
+
+        // MARK: - Location
+
+        func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
+            if status == .authorizedWhenInUse || status == .authorizedAlways {
+                manager.startUpdatingLocation()
+            }
+        }
+
+        func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+            guard !hasCenteredOnUser, let location = locations.last else { return }
+            centerOnUser(location)
+            hasCenteredOnUser = true
+        }
+
+        private func centerOnUser(_ location: CLLocation) {
+            let options = CameraOptions(center: location.coordinate, zoom: 14)
+            mapView?.mapboxMap.setCamera(to: options)
         }
     }
 }


### PR DESCRIPTION
## Summary
- update `MapboxMapView` coordinator to handle zoom-in/out notifications
- center map on the user's location when available
- request location permission in Info.plist

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684ef6ee3f7c8321a8e5b4b2a19d1578