### PR TITLE
Add Tips tab using Firestore

### DIFF
--- a/Tropka/Models/Tip.swift
+++ b/Tropka/Models/Tip.swift
@@ -1,0 +1,17 @@
+import Foundation
+import FirebaseFirestoreSwift
+
+struct TipPage: Identifiable, Codable {
+    let id: String
+    let imageURL: String
+    let header: String
+    let body: String
+    let footer: String?
+}
+
+struct Tip: Identifiable, Codable {
+    @DocumentID var id: String?
+    let title: String
+    let bannerURL: String
+    let pages: [TipPage]
+}

--- a/Tropka/Models/TipsViewModel.swift
+++ b/Tropka/Models/TipsViewModel.swift
@@ -1,0 +1,27 @@
+import Foundation
+import FirebaseFirestore
+import FirebaseFirestoreSwift
+
+@MainActor
+final class TipsViewModel: ObservableObject {
+    @Published var tips: [Tip] = []
+    @Published var isLoading = false
+    @Published var errorMessage: String?
+
+    private let db = Firestore.firestore()
+
+    func loadTips() async {
+        isLoading = true
+        errorMessage = nil
+        do {
+            let snapshot = try await db.collection("tips").getDocuments()
+            tips = try snapshot.documents.compactMap { doc in
+                try doc.data(as: Tip.self)
+            }
+            isLoading = false
+        } catch {
+            errorMessage = error.localizedDescription
+            isLoading = false
+        }
+    }
+}

--- a/Tropka/Views/CreatorView.swift
+++ b/Tropka/Views/CreatorView.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+
+struct CreatorView: View {
+    @StateObject private var vm = TipsViewModel()
+    @State private var selectedTip: Tip?
+
+    var body: some View {
+        NavigationStack {
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 16) {
+                    ForEach(vm.tips) { tip in
+                        Button {
+                            selectedTip = tip
+                        } label: {
+                            AsyncImage(url: URL(string: tip.bannerURL)) { phase in
+                                switch phase {
+                                case .empty:
+                                    ProgressView()
+                                        .frame(width: 240, height: 130)
+                                case .success(let image):
+                                    image
+                                        .resizable()
+                                        .scaledToFill()
+                                        .frame(width: 240, height: 130)
+                                        .clipped()
+                                case .failure:
+                                    Image(systemName: "photo")
+                                        .frame(width: 240, height: 130)
+                                        .background(Color.gray.opacity(0.2))
+                                @unknown default:
+                                    EmptyView()
+                                }
+                            }
+                            .cornerRadius(12)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+                .padding()
+            }
+            .navigationTitle("Tips")
+            .task { await vm.loadTips() }
+            .fullScreenCover(item: $selectedTip) { tip in
+                TipDetailView(tip: tip)
+            }
+        }
+    }
+}

--- a/Tropka/Views/MainTabView.swift
+++ b/Tropka/Views/MainTabView.swift
@@ -4,7 +4,7 @@ struct MainTabView: View {
     @State private var selection: Tab = .routes
 
     enum Tab {
-        case explore, map, routes, profile
+        case explore, map, routes, tips, profile
     }
 
     var body: some View {
@@ -23,12 +23,20 @@ struct MainTabView: View {
                 }
                 .tag(Tab.map)
 
+
             RoutesListView()
                 .tabItem {
                     Image(systemName: "list.bullet")
                     Text("Routes")
                 }
                 .tag(Tab.routes)
+
+            CreatorView()
+                .tabItem {
+                    Image(systemName: "lightbulb")
+                    Text("Tips")
+                }
+                .tag(Tab.tips)
 
             ProfileView()
                 .tabItem {

--- a/Tropka/Views/TipDetailView.swift
+++ b/Tropka/Views/TipDetailView.swift
@@ -1,0 +1,64 @@
+import SwiftUI
+
+struct TipDetailView: View {
+    let tip: Tip
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        ZStack(alignment: .topTrailing) {
+            TabView {
+                ForEach(tip.pages) { page in
+                    ScrollView {
+                        VStack(spacing: 16) {
+                            AsyncImage(url: URL(string: page.imageURL)) { phase in
+                                switch phase {
+                                case .empty:
+                                    ProgressView()
+                                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                                case .success(let image):
+                                    image
+                                        .resizable()
+                                        .scaledToFit()
+                                case .failure:
+                                    Image(systemName: "photo")
+                                        .resizable()
+                                        .scaledToFit()
+                                        .foregroundColor(.secondary)
+                                @unknown default:
+                                    EmptyView()
+                                }
+                            }
+                            .frame(maxWidth: .infinity)
+
+                            Text(page.header)
+                                .font(.title2)
+                                .bold()
+                                .multilineTextAlignment(.center)
+                                .padding(.top, 8)
+
+                            Text(page.body)
+                                .multilineTextAlignment(.leading)
+                                .padding(.horizontal)
+
+                            if let footer = page.footer {
+                                Text(footer)
+                                    .font(.footnote)
+                                    .foregroundColor(.secondary)
+                                    .padding(.top, 8)
+                            }
+                        }
+                        .padding()
+                    }
+                }
+            }
+            .tabViewStyle(.page(indexDisplayMode: .always))
+            .ignoresSafeArea()
+
+            Button(action: { dismiss() }) {
+                Image(systemName: "xmark.circle.fill")
+                    .font(.title)
+                    .padding()
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add Tip and TipPage codable models
- create TipsViewModel with Firestore integration
- implement new CreatorView for listing tips
- create TipDetailView for full-screen tip pages
- add Tips tab to MainTabView

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684f40607c888321a9ee1a620c57458f